### PR TITLE
Fix AW16G song lookup for non-contiguous song-info entries

### DIFF
--- a/src/class.awcontroller.tcl
+++ b/src/class.awcontroller.tcl
@@ -707,47 +707,67 @@ itcl::body AWController::song_at_index {index} {
     log_msg "Fetching $_ftype song at index $index."
 		
     if {$_ftype eq "AW16G"} {
-	    # finding AW16G songs is a little tricky
-	    
+	    # finding AW16G songs is a little tricky.
+	    #
+	    # User songs live in the song-info table starting at the entry
+	    # whose 'offset' field is zero. They are NOT guaranteed to occupy
+	    # consecutive slots after that — factory presets and stale entries
+	    # may be interleaved. We must skip over slots whose computed
+	    # song-block location is past EOF (i.e. the song's data lives on
+	    # a later disk in a multi-disk backup) or whose first track header
+	    # doesn't start with "V_TR" (i.e. the slot is junk).
+
         for {set i 0} {$i < $::awg::songinfo_max_count} {incr i} {
 	        set buffer {}
-			set location [expr ($i * $bufsz) + $start]
-			
-			# This song header exists on another disk???
-			# Current version of software is not capable of handling this.
-			if {[expr $location + $::awg::songblock_size] > [$_current bytes]} {
-			    set err "ERROR: Too many songs in backup file. Sorry"
-                log_msg $err
-				puts $err
-				flush stdout
-    		    return ""
+			set probe_loc [expr ($i * $bufsz) + $start]
+
+			# Reached the end of the song-info table itself?
+			if {[expr $probe_loc + $bufsz] > [$_current bytes]} {
+			    break
 			}
-			
-			# seek to song location, and pull in the info buffer
-			seek $_fh $location start
+
+			# seek to song-info entry, and pull in the info buffer
+			seek $_fh $probe_loc start
 			set buffer [read $_fh $bufsz]
-			
+
 		    # aw16g song offset number is very important in locating song data
 			binary scan [string range $buffer 0x20 [expr 0x20 + 4]] I* offset
-			
+
 			# offset of 0x0000 indicates beginning of the valid song blocks
 			if {$offset == 0} { incr found }
-			
-			if {$found} {
-    			if {$count == $index} {
-					# correct buffer found! update loction and offset values
-        		    set location [expr ($offset * $::aw::block_size) + \
-        		    					$::awg::songblock_location]
-        		    					
-        		    set name [clean_c_string [string range $buffer \
-        		    				$::awg::songinfo_name_offset \
-        							[expr $::awg::songinfo_name_offset + \
-        							$::awg::songinfo_name_size] ]]					
-            	    
-        		    break	
-    			}
-				incr count
-            }
+			if {! $found} { continue }
+
+			# Compute the candidate song-block location and validate it.
+			set candidate_loc [expr ($offset * $::aw::block_size) + \
+									$::awg::songblock_location]
+			if {[expr $candidate_loc + $::awg::songblock_size] > [$_current bytes]} {
+			    log_msg "Song-info entry $i offset 0x[format %x $offset] resolves past EOF; skipping (data is on another disk)."
+			    continue
+			}
+
+			# Verify there's a valid track header at the candidate location.
+			seek $_fh [expr $candidate_loc + $::awg::trackinfo_offset] start
+			set probe [read $_fh 4]
+			if {$probe ne "V_TR"} {
+			    log_msg "Song-info entry $i has no V_TR track header at 0x[format %x $candidate_loc]; skipping."
+			    continue
+			}
+
+			# Valid song-info entry. Is this the one we were asked for?
+			if {$count == $index} {
+        		set location $candidate_loc
+        		set name [clean_c_string [string range $buffer \
+        					$::awg::songinfo_name_offset \
+        					[expr $::awg::songinfo_name_offset + \
+        					$::awg::songinfo_name_size] ]]
+        		break
+			}
+			incr count
+        }
+
+        # End of table without finding the requested index -> no more songs.
+        if {$name eq ""} {
+            return ""
         }
     } else {
         # finding aw4416/2816 song buffers is easy!

--- a/src/class.awexporter.tcl
+++ b/src/class.awexporter.tcl
@@ -158,8 +158,15 @@ itcl::body AWExporter::frame_to_file {frame} {
 	}
 	
 	# determine starting location of this frame
+	#
+	# Audio frame numbers index the disk's shared audio area, which starts
+	# at songblock_location (the fixed constant). For song 0 this happens to
+	# equal the song's metadata location and the older form
+	#     [$song location] + frame * block_size
+	# gave correct results; for songs 1+ in a multi-song single-disk backup
+	# it would resolve far past EOF and look like a missing disk.
 	if {[$parent type] == "AW16G" && [[$parent current_file_object] index] == 0} {
-		set frameloc [expr [$song location] + [adjusted_frame_value $frame] * $::aw::block_size]
+		set frameloc [expr $::awg::songblock_location + [adjusted_frame_value $frame] * $::aw::block_size]
 	} else {
  	    set frameloc [expr $audioloc + ([adjusted_frame_value $frame] * $::aw::block_size)]
 	}


### PR DESCRIPTION
## Summary

`AWController::song_at_index`'s AW16G branch assumes user songs occupy *consecutive* entries in the 1000-slot song-info table at `0x35800`, starting at the entry whose `offset` field is zero. In real AW-16G backups, user songs are sparsely scattered through that table (which also contains factory presets, scenes, and stale slots), so the second and third "songs" the old algorithm picks up are usually junk entries whose computed song-block location lands far past EOF. The follow-up `read` in `tracks_for_song` then returns an empty buffer and the next `binary scan` crashes with:

```
can't use empty string as operand of "&"
    while executing
"expr { $region_ptr & 0xFFFF }"
    (object "::aWController0" method "::AWController::tracks_for_song" body line 37)
```

I hit this on a 3-song single-disk AW_00000.16G — the only one of those three whose audio was fully on the disk crashed the tool on file open.

## What the patch does

Keeps the "find the entry whose `offset` field is zero" anchor, but after that, validates every candidate slot before accepting it:

1. **Bounds-check** the computed song-block location (`offset * block_size + songblock_location + songblock_size`) against the file size. Slots whose data lives on a later disk (or is just bogus) get a log line and are skipped instead of dereferenced.
2. **Signature-check** the candidate location: the first track header at `song_loc + 0x800` must start with `"V_TR"`. Cheaply rejects stale / non-song slots.
3. When no valid Nth entry is found, `song_at_index` returns `""` so `init_with_file`'s loop breaks cleanly instead of constructing a song with empty fields.

The old in-loop check `if {[expr \$location + \$::awg::songblock_size] > [\$_current bytes]}` was comparing the song-info entry's location against the *song-block* size, which is a category error — that check is replaced with the correct one against the computed song-block location, applied per-candidate.

## Before / after on the test file

Before, `open ...AW_00000.16G` immediately crashes inside `tracks_for_song`.

After:

```
OK> open /path/AW_00000.16G
DATA: 0 AW16G {Just a girl} 16 44100 {0} 0 {V_TR01_1} ...
DATA: 0 AW16G {Just a girl} 16 44100 {0} 8 {V_TR02_1} ...
...  (9 tracks)
DATA: 1 AW16G {Bubba} 16 44100 {0} 0 {V_TR01_1} ...
DATA: 1 AW16G {Bubba} 16 44100 {0} 8 {V_TR02_1} ...
DATA: 2 AW16G {046 New Song} 16 44100 {0} 0 {V_TR01_1} ...
DATA: 2 AW16G {046 New Song} 16 44100 {0} 8 {V_TR02_1} ...
DONE:
OK> export 0 0 /tmp/justagirl_tr01.aif
DONE:
```

The exported AIFF (`afinfo`: 1 ch, 44100 Hz, 16-bit big-endian) plays back correctly.

## Test plan

- [ ] AW16G single-disk backup that previously crashed: now enumerates all songs, exports tracks.
- [ ] Confirm AW4416/AW2816 path is unaffected (the `else` branch is untouched, but a reviewer with a `.CFS` file can verify quickly).
- [ ] Multi-disk AW16G backup: the patched tool reports which songs need a later disk rather than crashing, but cross-disk frame walking isn't added here (that's a separate, larger change).

## Notes

Tcl 8.6 / Itcl 4.2.3 on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)